### PR TITLE
Do not generate usb_rst upon power-on reset

### DIFF
--- a/usb_utils.v
+++ b/usb_utils.v
@@ -144,18 +144,20 @@ module usb_reset_detect(
     input se0,
     output usb_rst);
 
+localparam cntr_rst_val = 19'd480000;
+
 reg[18:0] cntr;
 assign usb_rst = cntr == 1'b0;
 
 always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
-        cntr <= 1'b0;
+        cntr <= cntr_rst_val;
     end else begin
         if (se0) begin
             if (!usb_rst)
                 cntr <= cntr - 1'b1;
         end else begin
-            cntr <= 19'd480000;
+            cntr <= cntr_rst_val;
         end
     end
 end


### PR DESCRIPTION
USB specification restricts any communication until usb_rst arrives. It is required to perform correct enumeration of several devices simultaneously, for example, during reboot or cold start.
With the current implementation usb_rst strobe always arrives at the first clock after asynchronous reset. Thus external state machine cannot properly determine whether usb_rst arrived or not.