### PR TITLE
Add FuseSoC support and Github CI actions

### DIFF
--- a/.github/workflows/fusesoc.yml
+++ b/.github/workflows/fusesoc.yml
@@ -1,0 +1,33 @@
+name: run-fusesoc-targets
+on: [push]
+
+jobs:
+  build-openlane-sky130:
+    runs-on: ubuntu-latest
+    env:
+      REPO : usbcorev
+      VLNV : usbcorev
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: usbcorev
+      - run: echo "EDALIZE_LAUNCHER=el_docker" >> $GITHUB_ENV
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130 $VLNV
+
+  lint-verilator:
+    runs-on: ubuntu-latest
+    env:
+      REPO : usbcorev
+      VLNV : usbcorev
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: usbcorev
+      - run: sudo apt install verilator
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=lint $VLNV

--- a/data/sky130.tcl
+++ b/data/sky130.tcl
@@ -1,0 +1,6 @@
+set ::env(CLOCK_PORT) "clk_48"
+set ::env(CLOCK_NET) $::env(CLOCK_PORT)
+set ::env(FP_CORE_UTIL) 40
+set ::env(CLOCK_PERIOD) "12.55"
+set ::env(SYNTH_MAX_FANOUT) 6
+set ::env(PL_TARGET_DENSITY) [ expr ($::env(FP_CORE_UTIL)+5) / 100.0 ]

--- a/usbcorev.core
+++ b/usbcorev.core
@@ -1,0 +1,34 @@
+CAPI=2:
+
+name : ::usbcorev:0
+
+filesets:
+  rtl:
+    files:
+      - usb_ep_banked.v
+      - usb_ep.v
+      - usb_recv.v
+      - usb_tx.v
+      - usb_utils.v
+      - usb.v
+      - utils.v
+    file_type : verilogSource
+
+  sky130:
+    files: [data/sky130.tcl : {file_type : tclSource}]
+
+targets:
+  default:
+    filesets : [rtl]
+
+  lint:
+    default_tool : verilator
+    filesets : [rtl]
+    tools:
+      verilator: {mode: lint-only}
+    toplevel: usb
+
+  sky130:
+    default_tool : openlane
+    filesets: [rtl, sky130]
+    toplevel : usb


### PR DESCRIPTION
This adds a core description file for the usbcorev core that exposes targets for linting and for building a GDSII using OpenLANE. All targets are also implemented as Github actions so that they get run on every push to the repo.

Quick FuseSoC instructions:

 #install FuseSoC
pip3 install fusesoc
 #Create and enter a new workspace
mkdir workspace && cd workspace
 #Register usbcorev as a library in the workspace
fusesoc library add usbcorev /path/to/usbcorev
 #...if repo is available locally or...
fusesoc library add usbcorev https://github.com/avakar/usbcorev
 #...to get the upstream repo

 #To run lint
fusesoc run --target=lint usbcorev
 #To build with OpenLANE running in a docker container
EDALIZE_LAUNCHER=el_docker fusesoc run --target=sky130 usbcorev
 #List all targets
fusesoc core show usbcorev